### PR TITLE
fix: Remove empty/null `description` properties for AR and SV

### DIFF
--- a/ar/docusaurus-plugin-content-docs/current/accessibility-testing/LambdaTest.md
+++ b/ar/docusaurus-plugin-content-docs/current/accessibility-testing/LambdaTest.md
@@ -1,7 +1,6 @@
 ---
 id: lambdatest
 title: اختبار إمكانية الوصول LambdaTest
-description: 
 ---
 
 # اختبار إمكانية الوصول LambdaTest

--- a/sv/docusaurus-plugin-content-docs/current/accessibility-testing/LambdaTest.md
+++ b/sv/docusaurus-plugin-content-docs/current/accessibility-testing/LambdaTest.md
@@ -1,7 +1,6 @@
 ---
 id: lambdatest
 title: LambdaTest tillgänglighetstestning
-description: 
 ---
 
 # LambdaTest tillgänglighetstestning


### PR DESCRIPTION
Both the `/ar` and `/sv` had empty description properties, which the doc workflow in the main repository was treating as `null`. 

```
[INFO] [ar] Creating an optimized production build...
Error:  The following front matter:
---
id: lambdatest
title: اختبار إمكانية الوصول LambdaTest
description: null
---
contains invalid values for field(s): `description`.

- "description" must be a string

Error:  Loading of version failed for version current
```

Removes these empty properties so build may pass.